### PR TITLE
Add native return type to jsonSerialize()

### DIFF
--- a/src/Model/Token/Card.php
+++ b/src/Model/Token/Card.php
@@ -325,10 +325,8 @@ class Card implements \JsonSerializable
      * Implements the json serialize method and
      * return all object variables including
      * private/protected properties.
-     *
-     * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter($this->convertObjectVarsToSnake(), function ($item) {
             return $item !== null;

--- a/src/Model/Token/Customer.php
+++ b/src/Model/Token/Customer.php
@@ -88,10 +88,8 @@ class Customer implements \JsonSerializable
      * Implements the json serialize method and
      * return all object variables including
      * private/protected properties.
-     *
-     * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter($this->convertObjectVarsToSnake(), function ($item) {
             return $item !== null;

--- a/src/Request/GetTokenRequest.php
+++ b/src/Request/GetTokenRequest.php
@@ -55,10 +55,8 @@ class GetTokenRequest implements \JsonSerializable
      * Implements the json serialize method and
      * return all object variables including
      * private/protected properties.
-     *
-     * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter($this->convertObjectVarsToDashed(), function ($item) {
             return $item !== null;

--- a/src/Response/GetTokenResponse.php
+++ b/src/Response/GetTokenResponse.php
@@ -89,10 +89,8 @@ class GetTokenResponse implements ResponseInterface, \JsonSerializable
      * Implements the json serialize method and
      * return all object variables including
      * private/protected properties.
-     *
-     * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter($this->convertObjectVarsToSnake(), function ($item) {
             return $item !== null;

--- a/src/Util/JsonSerializable.php
+++ b/src/Util/JsonSerializable.php
@@ -15,10 +15,8 @@ trait JsonSerializable
      * Implements the json serialize method and
      * return all object variables including
      * private/protected properties.
-     *
-     * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_filter(get_object_vars($this), function ($item) {
             return $item !== null;


### PR DESCRIPTION
This fixes some `E_DEPRECATED` level warnings emitted when running on PHP 8.1.

There have been changes that mandate that concrete return types must exist in certain cases: https://php.watch/versions/8.1/internal-method-return-types

Example of warnings:

```
$ php -v
PHP 8.1.0 ...
$ composer install
$ vendor/bin/phpunit
...
PHP Deprecated:  Return type of Paytrail\SDK\Model\Item::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in .../paytrail-php-sdk/src/Util/JsonSerializable.php on line 21
...
```

Fixes https://github.com/paytrail/paytrail-php-sdk/issues/13