### PR TITLE
Ensured items are not required for a payment request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "phpunit/phpunit": "^8.4",
         "squizlabs/php_codesniffer": "^3.6",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpmd/phpmd": "^2.10"
+        "phpmd/phpmd": "^2.10",
+        "mockery/mockery": "^1.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -368,6 +368,10 @@ class Item implements \JsonSerializable, ItemInterface
     {
         $props = get_object_vars($this);
 
+        if ($props['unitPrice'] < 0) {
+            throw new ValidationException('Items UnitPrice can\'t be a negative number');
+        }
+
         if (filter_var($props['unitPrice'], FILTER_VALIDATE_INT) === false) {
             //throw new \Exception('UnitPrice is not an integer');
             throw new ValidationException('UnitPrice is not an integer');

--- a/src/Request/AbstractPaymentRequest.php
+++ b/src/Request/AbstractPaymentRequest.php
@@ -359,8 +359,11 @@ abstract class AbstractPaymentRequest implements \JsonSerializable, PaymentReque
      */
     public function setItems(?array $items) : PaymentRequestInterface
     {
+        $this->items = $items;
 
-        $this->items = array_values($items);
+        if ($items !== null) {
+            $this->items = array_values($items);
+        }
 
         return $this;
     }

--- a/tests/unit/Model/AbstractPaymentRequestTest.php
+++ b/tests/unit/Model/AbstractPaymentRequestTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace unit\Model;
+
+use Exception;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Paytrail\SDK\Model\Customer;
+use Paytrail\SDK\Model\Item;
+use Paytrail\SDK\Request\AbstractPaymentRequest;
+use ReflectionProperty;
+
+class AbstractPaymentRequestTest extends MockeryTestCase
+{
+
+    public function testValidationExceptionMessages(): void
+    {
+        $paymentRequest = $this->getMockForAbstractClass(AbstractPaymentRequest::class);
+
+        try {
+            $paymentRequest->validate();
+        } catch (Exception $e) {
+            $this->assertEquals('Amount is empty', $e->getMessage());
+        }
+
+        try {
+            $this->setProtectedProperty($paymentRequest, 'amount', 'ten');
+            $paymentRequest->validate();
+        } catch (Exception $e) {
+            $this->assertEquals('Amount is not a number', $e->getMessage());
+        }
+
+        try {
+            $paymentRequest->setAmount(10);
+            $this->setProtectedProperty($paymentRequest, 'items', 'string');
+            $paymentRequest->validate();
+        } catch (Exception $e) {
+            $this->assertEquals('Items needs to be type of array', $e->getMessage());
+        }
+
+        try {
+            $paymentRequest->setAmount(10);
+            $paymentRequest->setItems($this->getPaymentItems());
+            $paymentRequest->validate();
+        } catch (Exception $e) {
+            $this->assertEquals('Amount doesnt match ItemsTotal', $e->getMessage());
+        }
+
+        try {
+            $paymentRequest->setItems(null);
+            $paymentRequest->validate();
+        } catch (Exception $e) {
+            $this->assertEquals('Stamp is empty', $e->getMessage());
+        }
+
+        try {
+            $paymentRequest->setStamp('stamp');
+            $paymentRequest->validate();
+        } catch (Exception $e) {
+            $this->assertEquals('Reference is empty', $e->getMessage());
+        }
+
+        try {
+            $paymentRequest->setReference('reference');
+            $paymentRequest->validate();
+        } catch (Exception $e) {
+            $this->assertEquals('Currency is empty', $e->getMessage());
+        }
+
+        try {
+            $paymentRequest->setCurrency('USD');
+            $paymentRequest->validate();
+        } catch (Exception $e) {
+            $this->assertEquals('Unsupported currency chosen', $e->getMessage());
+        }
+
+        try {
+            $paymentRequest->setCurrency('EUR');
+            $paymentRequest->setLanguage('UN');
+            $paymentRequest->validate();
+        } catch (Exception $e) {
+            $this->assertEquals('Unsupported language chosen', $e->getMessage());
+        }
+
+        try {
+            $paymentRequest->setLanguage('EN');
+            $paymentRequest->validate();
+        } catch (Exception $e) {
+            $this->assertEquals('Customer is empty', $e->getMessage());
+        }
+
+        try {
+            $paymentRequest->setCustomer(new Customer);
+            $paymentRequest->validate();
+        } catch (Exception $e) {
+            $this->assertEquals('RedirectUrls is empty', $e->getMessage());
+        }
+    }
+
+    private function setProtectedProperty(AbstractPaymentRequest $paymentRequest, string $propertyName, string $value): void
+    {
+        $attribute = new ReflectionProperty($paymentRequest, $propertyName);
+        $attribute->setAccessible(true);
+        $attribute->setValue($paymentRequest, $value);
+    }
+
+    private function getPaymentItems(): array
+    {
+        return [
+            (new Item)
+                ->setStamp('someStamp')
+                ->setDeliveryDate('12.12.2020')
+                ->setProductCode('pr1')
+                ->setVatPercentage(25)
+                ->setUnitPrice(10)
+                ->setUnits(1),
+            (new Item)
+                ->setStamp('someOtherStamp')
+                ->setDeliveryDate('12.12.2020')
+                ->setProductCode('pr2')
+                ->setVatPercentage(25)
+                ->setUnitPrice(10)
+                ->setUnits(2),
+        ];
+    }
+
+}

--- a/tests/unit/Model/ItemTest.php
+++ b/tests/unit/Model/ItemTest.php
@@ -44,6 +44,13 @@ class ItemTest extends TestCase
         }
 
         try {
+            $i->setUnitPrice(-10);
+            $i->validate();
+        } catch (Exception $e) {
+            $this->assertStringContainsString('UnitPrice can\'t be a negative number', $e->getMessage());
+        }
+
+        try {
             $i->setUnitPrice(2);
             $i->validate();
         } catch (Exception $e) {

--- a/tests/unit/Request/PaymentRequestTest.php
+++ b/tests/unit/Request/PaymentRequestTest.php
@@ -22,7 +22,7 @@ class PaymentRequestTest extends TestCase
         }
     }
 
-    public function tesPaymentRequestWithoutItems(): void
+    public function testPaymentRequestWithoutItems(): void
     {
         $paymentRequest = $this->getPaymentRequest();
 

--- a/tests/unit/Request/PaymentRequestTest.php
+++ b/tests/unit/Request/PaymentRequestTest.php
@@ -35,25 +35,25 @@ class PaymentRequestTest extends TestCase
 
     private function getPaymentRequest(): PaymentRequest
     {
-        $payment = (new PaymentRequest())
+        $payment = (new PaymentRequest)
             ->setAmount(30)
             ->setStamp('RequestStamp')
             ->setReference('RequestReference123')
             ->setCurrency('EUR')
             ->setLanguage('EN');
 
-        $customer = (new Customer())
+        $customer = (new Customer)
             ->setEmail('customer@email.com');
 
         $payment->setCustomer($customer);
 
-        $callback = (new CallbackUrl())
+        $callback = (new CallbackUrl)
             ->setCancel('https://somedomain.com/cancel')
             ->setSuccess('https://somedomain.com/success');
 
         $payment->setCallbackUrls($callback);
 
-        $redirect = (new CallbackUrl())
+        $redirect = (new CallbackUrl)
             ->setSuccess('https://someother.com/success')
             ->setCancel('https://someother.com/cancel');
 
@@ -65,14 +65,14 @@ class PaymentRequestTest extends TestCase
     private function getPaymentItems(): array
     {
         return [
-            (new Item())
+            (new Item)
             ->setStamp('someStamp')
             ->setDeliveryDate('12.12.2020')
             ->setProductCode('pr1')
             ->setVatPercentage(25)
             ->setUnitPrice(10)
             ->setUnits(1),
-            (new Item())
+            (new Item)
             ->setStamp('someOtherStamp')
             ->setDeliveryDate('12.12.2020')
             ->setProductCode('pr2')

--- a/tests/unit/Request/PaymentRequestTest.php
+++ b/tests/unit/Request/PaymentRequestTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use Paytrail\SDK\Exception\ValidationException;
 use Paytrail\SDK\Model\CallbackUrl;
@@ -9,53 +9,76 @@ use PHPUnit\Framework\TestCase;
 
 class PaymentRequestTest extends TestCase
 {
-    public function testPaymentRequest()
+    public function testPaymentRequestWithItems(): void
     {
-        $r = new PaymentRequest();
-        $r->setAmount(30);
-        $r->setStamp('RequestStamp');
-        $r->setReference('RequestReference123');
-        $r->setCurrency('EUR');
-        $r->setLanguage('EN');
+        $paymentRequest = $this->getPaymentRequest();
 
-        $item1 = new Item();
-        $item1->setStamp('someStamp')
+        $paymentRequest->setItems($this->getPaymentItems());
+
+        try {
+            $this->assertEquals(true, $paymentRequest->validate());
+        } catch (ValidationException $e) {
+            $this->fail();
+        }
+    }
+
+    public function tesPaymentRequestWithoutItems(): void
+    {
+        $paymentRequest = $this->getPaymentRequest();
+
+        try {
+            $this->assertEquals(true, $paymentRequest->validate());
+        } catch (ValidationException $e) {
+            $this->fail();
+        }
+    }
+
+    private function getPaymentRequest(): PaymentRequest
+    {
+        $payment = (new PaymentRequest())
+            ->setAmount(30)
+            ->setStamp('RequestStamp')
+            ->setReference('RequestReference123')
+            ->setCurrency('EUR')
+            ->setLanguage('EN');
+
+        $customer = (new Customer())
+            ->setEmail('customer@email.com');
+
+        $payment->setCustomer($customer);
+
+        $callback = (new CallbackUrl())
+            ->setCancel('https://somedomain.com/cancel')
+            ->setSuccess('https://somedomain.com/success');
+
+        $payment->setCallbackUrls($callback);
+
+        $redirect = (new CallbackUrl())
+            ->setSuccess('https://someother.com/success')
+            ->setCancel('https://someother.com/cancel');
+
+        $payment->setRedirectUrls($redirect);
+
+        return $payment;
+    }
+
+    private function getPaymentItems(): array
+    {
+        return [
+            (new Item())
+            ->setStamp('someStamp')
             ->setDeliveryDate('12.12.2020')
             ->setProductCode('pr1')
             ->setVatPercentage(25)
             ->setUnitPrice(10)
-            ->setUnits(1);
-
-        $item2 = new Item();
-        $item2->setStamp('someOtherStamp')
+            ->setUnits(1),
+            (new Item())
+            ->setStamp('someOtherStamp')
             ->setDeliveryDate('12.12.2020')
             ->setProductCode('pr2')
             ->setVatPercentage(25)
             ->setUnitPrice(10)
-            ->setUnits(2);
-
-        $r->setItems([$item1, $item2]);
-
-        $c = new Customer();
-        $c->setEmail('customer@email.com');
-
-        $r->setCustomer($c);
-
-        $cb = new CallbackUrl();
-        $cb->setCancel('https://somedomain.com/cancel')
-            ->setSuccess('https://somedomain.com/success');
-
-        $r->setCallbackUrls($cb);
-
-        $redirect = new CallbackUrl();
-        $redirect->setSuccess('https://someother.com/success')
-            ->setCancel('https://someother.com/cancel');
-
-        $r->setRedirectUrls($redirect);
-
-        try {
-            $this->assertEquals(true, $r->validate());
-        } catch (ValidationException $e) {
-        }
+            ->setUnits(2),
+        ];
     }
 }


### PR DESCRIPTION
## Description of Problem

In order to complete a payment request with discount items, it's not possible to provide a discount item (negative value or a separate discount item).

Therefore in order to complete a payment request with a discount, no items can be provided, but validation rule require at least one item to be provided.

## Description of Changes

* Allowed a payment request to be made without providing any items for the request
* The item validation rules has been updated to check if a negative value has been provided, for a items price
