### PR TITLE
Fix exception handling on request timeout

### DIFF
--- a/src/Util/RequestClient.php
+++ b/src/Util/RequestClient.php
@@ -5,6 +5,7 @@ namespace Paytrail\SDK\Util;
 
 use GuzzleHttp\Client as GuzzleHttpClient;
 use GuzzleHttp\Exception\ClientException as GuzzleClientException;
+use GuzzleHttp\Exception\ConnectException as GuzzleConnectException;
 use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use Paytrail\SDK\Client;
 use Paytrail\SDK\Exception\ClientException;
@@ -19,6 +20,10 @@ class RequestClient
         $this->createClient();
     }
 
+    /**
+     * @throws ClientException
+     * @throws RequestException
+     */
     public function request(string $method, string $uri, array $options)
     {
         try {
@@ -31,6 +36,8 @@ class RequestClient
                 $clientException->setResponseCode($exception->getCode());
             }
             throw $clientException;
+        } catch (GuzzleConnectException $exception) {
+            throw new RequestException($exception->getMessage());
         }
         catch (GuzzleRequestException $exception) {
             throw new RequestException($exception->getMessage());

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -37,8 +37,6 @@ class ClientTest extends TestCase
 
     const COF_PLUGIN_VERSION = 'phpunit-test';
 
-    protected $args;
-
     protected $client;
 
     protected $item;
@@ -63,9 +61,7 @@ class ClientTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->args = ['timeout' => 20];
-
-        $this->client = new Client(self::MERCHANT_ID, self::SECRET, self::COF_PLUGIN_VERSION, $this->args);
+        $this->client = new Client(self::MERCHANT_ID, self::SECRET, self::COF_PLUGIN_VERSION);
 
         $this->item = (new Item())
             ->setDeliveryDate('2020-12-12')


### PR DESCRIPTION
## TL;DR

Since 2.0.0 and using Guzzle 7, the underlying Guzzle `ConnectException` is not caught when a network timeout occurs.

This fixes the problem by catching it (whether using Guzzle 6 or 7) and throws a `Paytrail\SDK\Exception\RequestException` instead.

## Explanation

In 2.0.0 the SDK was refactored to not throw Guzzle Exceptions, but `Paytrail\SDK\Exception\*` instead. This conversion is done in `RequestClient->request()` when the actual Guzzle request in handled.

There are differences between Guzzle 6 and 7 Exception inheritance, which caused the problem:

### Guzzle 6

https://docs.guzzlephp.org/en/6.5/quickstart.html#exceptions

```
. \RuntimeException
├── SeekException (implements GuzzleException)
└── TransferException (implements GuzzleException)
    └── RequestException
        ├── BadResponseException
        │   ├── ServerException
        │   └── ClientException
        ├── ConnectException
        └── TooManyRedirectsException
```

Note: `\RuntimeException` -> `TransferException` -> `RequestException` -> `ConnectException`

### Guzzle 7

https://docs.guzzlephp.org/en/stable/quickstart.html#exceptions (Note that selecting version 7.0 here produces wrong documentation...)

```
. \RuntimeException
└── TransferException (implements GuzzleException)
    ├── ConnectException (implements NetworkExceptionInterface)
    └── RequestException
        ├── BadResponseException
        │   ├── ServerException
        │   └── ClientException
        └── TooManyRedirectsException
```

Note: `\RuntimeException` -> `TransferException` -> `ConnectException`

### The timeout issue

When using this SDK 2.0.0 and Guzzle 7, network timeouts are not caught because `ConnectException` is not caught by the `RequestClient->request()` method (it catches Guzzle's `ClientException` and `RequestException`)

`ConnectException` is caught when using Guzzle 6.

### The fix

Catch Guzzle's `ConnectException` explicitly, and throw `Paytrail\SDK\Exception\RequestException` instead. It works for Guzzle 6 and 7.