### PR TITLE
Add missing query parameters to URL on CurlClient

### DIFF
--- a/src/Util/CurlClient.php
+++ b/src/Util/CurlClient.php
@@ -27,7 +27,7 @@ class CurlClient
     public function request(string $method, string $uri, array $options)
     {
         $curl = curl_init();
-        curl_setopt($curl, CURLOPT_URL, $this->baseUrl . $uri);
+        curl_setopt($curl, CURLOPT_URL, $this->buildUrl($uri, $options));
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_HEADER, true);
@@ -53,6 +53,23 @@ class CurlClient
         curl_close($curl);
 
         return $curlResponse;
+    }
+
+    /**
+     * Build URL by prefixing endpoint with base URL and possible query parameters.
+     *
+     * @param string $uri
+     * @param array $options
+     * @return string
+     */
+    private function buildUrl(string $uri, array $options): string
+    {
+        $query = '';
+        if (isset($options['query'])) {
+            $uri .= '?' . http_build_query($options['query']);
+        }
+
+        return $this->baseUrl . $uri . $query;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -562,4 +562,11 @@ class ClientTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->client->getSettlements('30.5.2022');
     }
+
+    public function testGetGroupedPaymentProvidersAcceptsLanguageParameters()
+    {
+        $providers = $this->client->getGroupedPaymentProviders(100, 'EN');
+        $this->assertIsArray($providers);
+        $this->assertEquals('Mobile payment methods', $providers['groups'][0]['name']);
+    }
 }


### PR DESCRIPTION
CurlClient is missing query parameters on API URL, add them with unit test.

Fixes #45 
