### PR TITLE
Add/payment response fields

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -217,6 +217,9 @@ class Client extends PaytrailClient
                 return (new PaymentResponse())
                     ->setTransactionId($decoded->transactionId ?? null)
                     ->setHref($decoded->href ?? null)
+                    ->setTerms($decoded->terms ?? null)
+                    ->setGroups($decoded->groups ?? [])
+                    ->setReference($decoded->reference ?? null)
                     ->setProviders($decoded->providers ?? []);
             }
         );
@@ -252,6 +255,9 @@ class Client extends PaytrailClient
                  return (new PaymentResponse())
                      ->setTransactionId($decoded->transactionId ?? null)
                      ->setHref($decoded->href ?? null)
+                     ->setTerms($decoded->terms ?? null)
+                     ->setGroups($decoded->groups ?? [])
+                     ->setReference($decoded->reference ?? null)
                      ->setProviders($decoded->providers ?? []);
              }
          );

--- a/src/Client.php
+++ b/src/Client.php
@@ -217,7 +217,7 @@ class Client extends PaytrailClient
                 return (new PaymentResponse())
                     ->setTransactionId($decoded->transactionId ?? null)
                     ->setHref($decoded->href ?? null)
-                    ->setProviders($decoded->providers ?? null);
+                    ->setProviders($decoded->providers ?? []);
             }
         );
 
@@ -252,7 +252,7 @@ class Client extends PaytrailClient
                  return (new PaymentResponse())
                      ->setTransactionId($decoded->transactionId ?? null)
                      ->setHref($decoded->href ?? null)
-                     ->setProviders($decoded->providers ?? null);
+                     ->setProviders($decoded->providers ?? []);
              }
          );
 

--- a/src/Model/PaymentMethodGroup.php
+++ b/src/Model/PaymentMethodGroup.php
@@ -1,0 +1,144 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Class PaymentMethodGroup
+ */
+
+namespace Paytrail\SDK\Model;
+
+use Paytrail\SDK\Util\PropertyBinder;
+use Paytrail\SDK\Util\JsonSerializable;
+
+/**
+ * Class PaymentMethodGroup
+ *
+ * @see https://docs.paytrail.com/#/?id=paymentmethodgroup
+ * @package Paytrail\SDK\Model
+ */
+class PaymentMethodGroup implements \JsonSerializable
+{
+
+    use JsonSerializable;
+    use PropertyBinder;
+
+    /**
+     * Payment method group id.
+     *
+     * @var string|null
+     */
+    protected $id;
+
+    /**
+     * Payment method group name.
+     *
+     * @var string|null
+     */
+    protected $name;
+
+    /**
+     * Payment method group icon url.
+     *
+     * @var string|null
+     */
+    protected $icon;
+
+    /**
+     * Payment method group svg url.
+     *
+     * @var string|null
+     */
+    protected $svg;
+
+    /**
+     * Get payment method group id.
+     *
+     * @return string
+     */
+    public function getId() : ?string
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set payment method group id.
+     *
+     * @param string|null $id
+     * @return self
+     */
+    public function setId(?string $id) : self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * Get payment method group name.
+     *
+     * @return string|null
+     */
+    public function getName() : ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set payment method group name.
+     *
+     * @param string|null $name
+     * @return self
+     */
+    public function setName(?string $name) : self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Get payment method group svg url.
+     *
+     * @return string|null
+     */
+    public function getSvg() : ?string
+    {
+        return $this->svg;
+    }
+
+    /**
+     * Set payment method group svg url.
+     *
+     * @param string|null $svg
+     * @return self
+     */
+    public function setSvg(?string $svg) : self
+    {
+        $this->svg = $svg;
+
+        return $this;
+    }
+
+    /**
+     * Get payment method group icon url.
+     *
+     * @return string|null
+     */
+    public function getIcon() : ?string
+    {
+        return $this->icon;
+    }
+
+    /**
+     * Set payment method group icon url.
+     *
+     * @param string|null $icon
+     * @return self
+     */
+    public function setIcon(?string $icon) : self
+    {
+        $this->icon = $icon;
+
+        return $this;
+    }
+}

--- a/src/Model/PaymentMethodGroup.php
+++ b/src/Model/PaymentMethodGroup.php
@@ -1,9 +1,6 @@
 <?php
-declare(strict_types=1);
 
-/**
- * Class PaymentMethodGroup
- */
+declare(strict_types=1);
 
 namespace Paytrail\SDK\Model;
 
@@ -18,7 +15,6 @@ use Paytrail\SDK\Util\JsonSerializable;
  */
 class PaymentMethodGroup implements \JsonSerializable
 {
-
     use JsonSerializable;
     use PropertyBinder;
 
@@ -55,7 +51,7 @@ class PaymentMethodGroup implements \JsonSerializable
      *
      * @return string
      */
-    public function getId() : ?string
+    public function getId(): ?string
     {
         return $this->id;
     }
@@ -66,7 +62,7 @@ class PaymentMethodGroup implements \JsonSerializable
      * @param string|null $id
      * @return self
      */
-    public function setId(?string $id) : self
+    public function setId(?string $id): self
     {
         $this->id = $id;
 
@@ -78,7 +74,7 @@ class PaymentMethodGroup implements \JsonSerializable
      *
      * @return string|null
      */
-    public function getName() : ?string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -89,7 +85,7 @@ class PaymentMethodGroup implements \JsonSerializable
      * @param string|null $name
      * @return self
      */
-    public function setName(?string $name) : self
+    public function setName(?string $name): self
     {
         $this->name = $name;
 
@@ -101,7 +97,7 @@ class PaymentMethodGroup implements \JsonSerializable
      *
      * @return string|null
      */
-    public function getSvg() : ?string
+    public function getSvg(): ?string
     {
         return $this->svg;
     }
@@ -112,7 +108,7 @@ class PaymentMethodGroup implements \JsonSerializable
      * @param string|null $svg
      * @return self
      */
-    public function setSvg(?string $svg) : self
+    public function setSvg(?string $svg): self
     {
         $this->svg = $svg;
 
@@ -124,7 +120,7 @@ class PaymentMethodGroup implements \JsonSerializable
      *
      * @return string|null
      */
-    public function getIcon() : ?string
+    public function getIcon(): ?string
     {
         return $this->icon;
     }
@@ -135,7 +131,7 @@ class PaymentMethodGroup implements \JsonSerializable
      * @param string|null $icon
      * @return self
      */
-    public function setIcon(?string $icon) : self
+    public function setIcon(?string $icon): self
     {
         $this->icon = $icon;
 

--- a/src/Response/CitPaymentResponse.php
+++ b/src/Response/CitPaymentResponse.php
@@ -31,14 +31,13 @@ class CitPaymentResponse implements ResponseInterface
     /**
      * Set the transaction id.
      *
-     * @param string $transactionId
+     * @param string|null $transactionId
      *
      * @return CitPaymentResponse Return self to enable chaining.
      */
-    public function setTransactionId(string $transactionId): CitPaymentResponse
+    public function setTransactionId(?string $transactionId): CitPaymentResponse
     {
         $this->transactionId = $transactionId;
-
         return $this;
     }
 
@@ -53,7 +52,7 @@ class CitPaymentResponse implements ResponseInterface
     }
 
     /**
-     * @param string $threeDSecureUrl
+     * @param string|null $threeDSecureUrl
      * @return CitPaymentResponse
      */
     public function setThreeDSecureUrl(?string $threeDSecureUrl): CitPaymentResponse

--- a/src/Response/MitPaymentResponse.php
+++ b/src/Response/MitPaymentResponse.php
@@ -28,14 +28,13 @@ class MitPaymentResponse implements ResponseInterface
     /**
      * Set the transaction id.
      *
-     * @param string $transactionId
+     * @param string|null $transactionId
      *
      * @return MitPaymentResponse Return self to enable chaining.
      */
-    public function setTransactionId(string $transactionId): MitPaymentResponse
+    public function setTransactionId(?string $transactionId): MitPaymentResponse
     {
         $this->transactionId = $transactionId;
-
         return $this;
     }
 

--- a/src/Response/PaymentResponse.php
+++ b/src/Response/PaymentResponse.php
@@ -197,19 +197,13 @@ class PaymentResponse implements ResponseInterface
      */
     public function setProviders(array $providers) : PaymentResponse
     {
-        if (empty($providers)) {
-            return $this;
-        }
-
-        array_walk($providers, function ($provider) {
-            if (! $provider instanceof  Provider) {
-                $instance = new Provider();
-                $instance->bindProperties($provider);
-                $this->providers[] = $instance;
-            } else {
-                $this->providers[] = $provider;
+        $this->providers = array_map(function ($provider) {
+            if (! $provider instanceof Provider) {
+                return (new Provider())->bindProperties($provider);
             }
-        });
+
+            return $provider;
+        }, $providers);
 
         return $this;
     }

--- a/src/Response/PaymentResponse.php
+++ b/src/Response/PaymentResponse.php
@@ -23,14 +23,14 @@ class PaymentResponse implements ResponseInterface
     /**
      * The transaction id.
      *
-     * @var string
+     * @var string|null
      */
     protected $transactionId;
 
     /**
      * Payment API url.
      *
-     * @var string
+     * @var string|null
      */
     protected $href;
 
@@ -44,7 +44,7 @@ class PaymentResponse implements ResponseInterface
     /**
      * Get the transaction id.
      *
-     * @return string
+     * @return string|null
      */
     public function getTransactionId() : ?string
     {
@@ -54,11 +54,11 @@ class PaymentResponse implements ResponseInterface
     /**
      * Set the transaction id.
      *
-     * @param string $transactionId
+     * @param string|null $transactionId
      *
      * @return PaymentResponse Return self to enable chaining.
      */
-    public function setTransactionId(string $transactionId) : PaymentResponse
+    public function setTransactionId(?string $transactionId) : PaymentResponse
     {
         $this->transactionId = $transactionId;
 
@@ -68,7 +68,7 @@ class PaymentResponse implements ResponseInterface
     /**
      * Get the href.
      *
-     * @return string
+     * @return string|null
      */
     public function getHref() : ?string
     {
@@ -78,11 +78,11 @@ class PaymentResponse implements ResponseInterface
     /**
      * Set the href.
      *
-     * @param string $href
+     * @param string|null $href
      *
      * @return PaymentResponse Return self to enable chaining.
      */
-    public function setHref(string $href) : PaymentResponse
+    public function setHref(?string $href) : PaymentResponse
     {
         $this->href = $href;
 
@@ -92,11 +92,10 @@ class PaymentResponse implements ResponseInterface
     /**
      * Get providers.
      *
-     * @return Provider[]
+     * @return Provider[]|null
      */
     public function getProviders() : ?array
     {
-
         return $this->providers;
     }
 
@@ -111,7 +110,7 @@ class PaymentResponse implements ResponseInterface
      *
      * @return PaymentResponse Return self to enable chaining.
      */
-    public function setProviders(?array $providers) : PaymentResponse
+    public function setProviders(array $providers) : PaymentResponse
     {
         if (empty($providers)) {
             return $this;

--- a/src/Response/PaymentResponse.php
+++ b/src/Response/PaymentResponse.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Paytrail\SDK\Response;
 
+use Paytrail\SDK\Model\PaymentMethodGroup;
 use Paytrail\SDK\Model\Provider;
 use Paytrail\SDK\Interfaces\ResponseInterface;
 
@@ -21,18 +22,39 @@ class PaymentResponse implements ResponseInterface
 {
 
     /**
-     * The transaction id.
+     * Assigned transaction ID for the payment.
      *
      * @var string|null
      */
     protected $transactionId;
 
     /**
-     * Payment API url.
+     * URL to hosted payment gateway.
      *
      * @var string|null
      */
     protected $href;
+
+    /**
+     * Localized text with a link to the terms of payment.
+     *
+     * @var string|null
+     */
+    protected $terms;
+
+    /**
+     * Array of payment method group data with localized names and URLs to icons.
+     *
+     * @var PaymentMethodGroup[]
+     */
+    protected $groups = [];
+
+    /**
+     * The bank reference used for the payments.
+     *
+     * @var string|null
+     */
+    protected $reference;
 
     /**
      * Payment providers.
@@ -85,6 +107,69 @@ class PaymentResponse implements ResponseInterface
     public function setHref(?string $href) : PaymentResponse
     {
         $this->href = $href;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTerms(): ?string
+    {
+        return $this->terms;
+    }
+
+    /**
+     * @param string|null $terms
+     * @return PaymentResponse
+     */
+    public function setTerms(?string $terms): PaymentResponse
+    {
+        $this->terms = $terms;
+
+        return $this;
+    }
+
+    /**
+     * @return PaymentMethodGroup[]
+     */
+    public function getGroups(): array
+    {
+        return $this->groups;
+    }
+
+    /**
+     * @param PaymentMethodGroup[]|array $groups
+     * @return PaymentResponse
+     */
+    public function setGroups(array $groups): PaymentResponse
+    {
+        $this->groups = array_map(function ($group) {
+            if (! $group instanceof Provider) {
+                return (new Provider())->bindProperties($group);
+            }
+
+            return $group;
+        }, $groups);
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getReference(): ?string
+    {
+        return $this->reference;
+    }
+
+    /**
+     * @param string|null $reference
+     * @return PaymentResponse
+     */
+    public function setReference(?string $reference): PaymentResponse
+    {
+        $this->reference = $reference;
 
         return $this;
     }

--- a/src/Response/PaymentResponse.php
+++ b/src/Response/PaymentResponse.php
@@ -1,9 +1,6 @@
 <?php
-declare(strict_types=1);
 
-/**
- * Class PaymentResponse
- */
+declare(strict_types=1);
 
 namespace Paytrail\SDK\Response;
 
@@ -20,7 +17,6 @@ use Paytrail\SDK\Interfaces\ResponseInterface;
  */
 class PaymentResponse implements ResponseInterface
 {
-
     /**
      * Assigned transaction ID for the payment.
      *
@@ -68,7 +64,7 @@ class PaymentResponse implements ResponseInterface
      *
      * @return string|null
      */
-    public function getTransactionId() : ?string
+    public function getTransactionId(): ?string
     {
         return $this->transactionId;
     }
@@ -80,7 +76,7 @@ class PaymentResponse implements ResponseInterface
      *
      * @return PaymentResponse Return self to enable chaining.
      */
-    public function setTransactionId(?string $transactionId) : PaymentResponse
+    public function setTransactionId(?string $transactionId): PaymentResponse
     {
         $this->transactionId = $transactionId;
 
@@ -92,7 +88,7 @@ class PaymentResponse implements ResponseInterface
      *
      * @return string|null
      */
-    public function getHref() : ?string
+    public function getHref(): ?string
     {
         return $this->href;
     }
@@ -104,7 +100,7 @@ class PaymentResponse implements ResponseInterface
      *
      * @return PaymentResponse Return self to enable chaining.
      */
-    public function setHref(?string $href) : PaymentResponse
+    public function setHref(?string $href): PaymentResponse
     {
         $this->href = $href;
 
@@ -179,7 +175,7 @@ class PaymentResponse implements ResponseInterface
      *
      * @return Provider[]|null
      */
-    public function getProviders() : ?array
+    public function getProviders(): ?array
     {
         return $this->providers;
     }
@@ -195,7 +191,7 @@ class PaymentResponse implements ResponseInterface
      *
      * @return PaymentResponse Return self to enable chaining.
      */
-    public function setProviders(array $providers) : PaymentResponse
+    public function setProviders(array $providers): PaymentResponse
     {
         $this->providers = array_map(function ($provider) {
             if (! $provider instanceof Provider) {

--- a/src/Response/PaymentStatusResponse.php
+++ b/src/Response/PaymentStatusResponse.php
@@ -35,7 +35,7 @@ class PaymentStatusResponse implements ResponseInterface
 
     /**
      * Total amount of the payment in currency's minor units,
-     * eg. for Euros means cents.
+     * e.g. for Euros means cents.
      *
      * @var integer
      */
@@ -137,7 +137,7 @@ class PaymentStatusResponse implements ResponseInterface
     /**
      * Set the payment status.
      *
-     * @param string $status Possible values: new, ok, fail,
+     * @param string|null $status Possible values: new, ok, fail,
      * pending, or delayed
      *
      * @return PaymentStatusResponse Return self to enable chaining.
@@ -145,7 +145,6 @@ class PaymentStatusResponse implements ResponseInterface
     public function setStatus(?string $status): PaymentStatusResponse
     {
         $this->status = $status;
-
         return $this;
     }
 
@@ -161,16 +160,15 @@ class PaymentStatusResponse implements ResponseInterface
 
     /**
      * Set the total amount of the payment in currency's minor units,
-     * eg. for Euros means cents.
+     * e.g. for Euros means cents.
      *
-     * @param integer $amount
+     * @param integer|null $amount
      *
      * @return PaymentStatusResponse Return self to enable chaining.
      */ 
     public function setAmount(?int $amount): PaymentStatusResponse
     {
         $this->amount = $amount;
-
         return $this;
     }
 
@@ -187,14 +185,13 @@ class PaymentStatusResponse implements ResponseInterface
     /**
      * Set currency.
      *
-     * @param string $currency
+     * @param string|null $currency
      *
      * @return PaymentStatusResponse Return self to enable chaining.
      */ 
     public function setCurrency(?string $currency): PaymentStatusResponse
     {
         $this->currency = $currency;
-
         return $this;
     }
 
@@ -211,14 +208,13 @@ class PaymentStatusResponse implements ResponseInterface
     /**
      * Set merchant unique identifier for the order.
      *
-     * @param string $stamp
+     * @param string|null $stamp
      *
      * @return PaymentStatusResponse Return self to enable chaining.
      */ 
     public function setStamp(?string $stamp): PaymentStatusResponse
     {
         $this->stamp = $stamp;
-
         return $this;
     }
 
@@ -227,7 +223,7 @@ class PaymentStatusResponse implements ResponseInterface
      *
      * @return string
      */ 
-    public function getReference()
+    public function getReference(): string
     {
         return $this->reference;
     }
@@ -235,14 +231,13 @@ class PaymentStatusResponse implements ResponseInterface
     /**
      * Set the order reference.
      *
-     * @param string $reference
+     * @param string|null $reference
      *
      * @return PaymentStatusResponse Return self to enable chaining.
      */ 
     public function setReference(?string $reference): PaymentStatusResponse
     {
         $this->reference = $reference;
-
         return $this;
     }
 
@@ -259,14 +254,13 @@ class PaymentStatusResponse implements ResponseInterface
     /**
      * Set the transaction creation timestamp.
      *
-     * @param string $createdAt
+     * @param string|null $createdAt
      *
      * @return PaymentStatusResponse Return self to enable chaining.
      */ 
     public function setCreatedAt(?string $createdAt): PaymentStatusResponse
     {
         $this->createdAt = $createdAt;
-
         return $this;
     }
 
@@ -283,14 +277,13 @@ class PaymentStatusResponse implements ResponseInterface
     /**
      * Set payment API url.
      *
-     * @param string $href
+     * @param string|null $href
      *
      * @return PaymentStatusResponse Return self to enable chaining.
      */ 
     public function setHref(?string $href): PaymentStatusResponse
     {
         $this->href = $href;
-
         return $this;
     }
 
@@ -307,14 +300,13 @@ class PaymentStatusResponse implements ResponseInterface
     /**
      * Set provider name.
      *
-     * @param string $provider If processed, the name of the payment method provider
+     * @param string|null $provider If processed, the name of the payment method provider
      *
      * @return PaymentStatusResponse Return self to enable chaining.
      */ 
     public function setProvider(?string $provider): PaymentStatusResponse
     {
         $this->provider = $provider;
-
         return $this;
     }
 
@@ -331,14 +323,13 @@ class PaymentStatusResponse implements ResponseInterface
     /**
      * Set filing code.
      *
-     * @param string $filingCode
+     * @param string|null $filingCode
      *
      * @return PaymentStatusResponse Return self to enable chaining.
      */ 
     public function setFilingCode(?string $filingCode): PaymentStatusResponse
     {
         $this->filingCode = $filingCode;
-
         return $this;
     }
 
@@ -355,14 +346,13 @@ class PaymentStatusResponse implements ResponseInterface
     /**
      * Set timestamp when the transaction was paid
      *
-     * @param string $paidAt
+     * @param string|null $paidAt
      *
      * @return PaymentStatusResponse Return self to enable chaining.
      */ 
     public function setPaidAt(?string $paidAt): PaymentStatusResponse
     {
         $this->paidAt = $paidAt;
-
         return $this;
     }
 }

--- a/src/Response/RefundResponse.php
+++ b/src/Response/RefundResponse.php
@@ -52,7 +52,7 @@ class RefundResponse implements ResponseInterface
     /**
      * Set the provider.
      *
-     * @param string $provider
+     * @param string|null $provider
      *
      * @return RefundResponse Return self to enable chaining.
      */
@@ -78,7 +78,7 @@ class RefundResponse implements ResponseInterface
     /**
      * Set the status.
      *
-     * @param string $status
+     * @param string|null $status
      *
      * @return RefundResponse Return self to enable chaining.
      */
@@ -104,7 +104,7 @@ class RefundResponse implements ResponseInterface
     /**
      * Set the transactionId.
      *
-     * @param string $transactionId
+     * @param string|null $transactionId
      *
      * @return RefundResponse Return self to enable chaining.
      */

--- a/src/Response/RevertPaymentAuthHoldResponse.php
+++ b/src/Response/RevertPaymentAuthHoldResponse.php
@@ -28,14 +28,13 @@ class RevertPaymentAuthHoldResponse implements ResponseInterface
     /**
      * Set the transaction id.
      *
-     * @param string $transactionId
+     * @param string|null $transactionId
      *
-     * @return CitPaymentResponse Return self to enable chaining.
+     * @return RevertPaymentAuthHoldResponse Return self to enable chaining.
      */
-    public function setTransactionId(string $transactionId): RevertPaymentAuthHoldResponse
+    public function setTransactionId(?string $transactionId): RevertPaymentAuthHoldResponse
     {
         $this->transactionId = $transactionId;
-
         return $this;
     }
 
@@ -44,7 +43,7 @@ class RevertPaymentAuthHoldResponse implements ResponseInterface
      *
      * @return string
      */
-    public function getTransactionId(): string
+    public function getTransactionId(): ?string
     {
         return $this->transactionId;
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests;
@@ -169,7 +170,7 @@ class ClientTest extends PaymentRequestTestCase
             $res = $this->client->getPaymentStatus($psr);
             $this->assertEquals('new', $res->getStatus());
             $this->assertEquals($transactionId, $res->getTransactionId());
-        } catch (HmacException|ValidationException $e) {
+        } catch (HmacException | ValidationException $e) {
             $this->fail($e->getMessage());
         }
     }
@@ -189,7 +190,7 @@ class ClientTest extends PaymentRequestTestCase
             $res = $this->sisClient->getPaymentStatus($psr);
             $this->assertEquals('new', $res->getStatus());
             $this->assertEquals($transactionId, $res->getTransactionId());
-        } catch (HmacException|ValidationException $e) {
+        } catch (HmacException | ValidationException $e) {
             $this->fail($e->getMessage());
         }
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -6,7 +6,6 @@ namespace Tests;
 use Paytrail\SDK\Client;
 use Paytrail\SDK\Exception\ClientException;
 use Paytrail\SDK\Exception\HmacException;
-use Paytrail\SDK\Exception\RequestException;
 use Paytrail\SDK\Exception\ValidationException;
 use Paytrail\SDK\Model\Address;
 use Paytrail\SDK\Model\CallbackUrl;
@@ -22,24 +21,9 @@ use Paytrail\SDK\Request\PaymentStatusRequest;
 use Paytrail\SDK\Request\ReportRequest;
 use Paytrail\SDK\Request\RevertPaymentAuthHoldRequest;
 use Paytrail\SDK\Request\ShopInShopPaymentRequest;
-use PHPUnit\Framework\TestCase;
 
-class ClientTest extends TestCase
+class ClientTest extends PaymentRequestTestCase
 {
-    const SECRET = 'SAIPPUAKAUPPIAS';
-
-    const MERCHANT_ID = 375917;
-
-    const SHOP_IN_SHOP_SECRET = 'MONISAIPPUAKAUPPIAS';
-
-    const SHOP_IN_SHOP_AGGREGATE_MERCHANT_ID = 695861;
-
-    const SHOP_IN_SHOP_SUB_MERCHANT_ID = '695874';
-
-    const COF_PLUGIN_VERSION = 'phpunit-test';
-
-    protected $client;
-
     protected $item;
 
     protected $item2;
@@ -62,7 +46,7 @@ class ClientTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->client = new Client(self::MERCHANT_ID, self::SECRET, self::COF_PLUGIN_VERSION);
+        parent::setUp();
 
         $this->item = (new Item())
             ->setDeliveryDate('2020-12-12')
@@ -172,93 +156,41 @@ class ClientTest extends TestCase
 
     public function testPaymentRequest()
     {
-        $client = $this->client;
-        $paymentRequest = $this->paymentRequest;
+        $response = $this->createPayment($this->paymentRequest);
+        $this->assertPaymentResponseIsValid($response);
 
-        $transactionId = '';
-
-        if ($paymentRequest->validate()) {
-            try {
-                $response = $client->createPayment($paymentRequest);
-
-                $this->assertObjectHasAttribute('transactionId', $response);
-                $this->assertObjectHasAttribute('href', $response);
-                $this->assertObjectHasAttribute('providers', $response);
-                $this->assertIsArray($response->getProviders());
-
-                $transactionId = $response->getTransactionId();
-
-            } catch (HmacException $e) {
-                var_dump($e->getMessage());
-            } catch (ValidationException $e) {
-                var_dump($e->getMessage());
-            } catch (RequestException $e) {
-                var_dump(json_decode($e->getResponse()->getBody()));
-            }
-
-        } else {
-            echo 'PaymentRequest is not valid';
-        }
+        $transactionId = $response->getTransactionId();
 
         // Test payment status request with the transactionId we got from the PaymentRequest
         $psr = new PaymentStatusRequest();
         $psr->setTransactionId($transactionId);
 
-        $client = new Client(self::MERCHANT_ID, self::SECRET, self::COF_PLUGIN_VERSION);
-
         try {
-            $res = $client->getPaymentStatus($psr);
+            $res = $this->client->getPaymentStatus($psr);
             $this->assertEquals('new', $res->getStatus());
-            $this->assertEquals($res->getTransactionId(), $transactionId);
-        } catch (HmacException $e) {
-            var_dump('hmac error');
-        } catch (ValidationException $e) {
-            var_dump('validation error');
+            $this->assertEquals($transactionId, $res->getTransactionId());
+        } catch (HmacException|ValidationException $e) {
+            $this->fail($e->getMessage());
         }
     }
 
     public function testShopInShopPaymentRequest()
     {
-        $client = new Client(self::SHOP_IN_SHOP_AGGREGATE_MERCHANT_ID, self::SHOP_IN_SHOP_SECRET, self::COF_PLUGIN_VERSION);
-        $paymentRequest = $this->shopInShopPaymentRequest;
+        $response = $this->createShopInShopPayment($this->shopInShopPaymentRequest);
+        $this->assertPaymentResponseIsValid($response);
 
-        $transactionId = '';
-
-        if ($paymentRequest->validate()) {
-            try {
-                $response = $client->createShopInShopPayment($paymentRequest);
-
-                $this->assertObjectHasAttribute('transactionId', $response);
-                $this->assertObjectHasAttribute('href', $response);
-                $this->assertObjectHasAttribute('providers', $response);
-                $this->assertIsArray($response->getProviders());
-
-                $transactionId = $response->getTransactionId();
-
-            } catch (HmacException $e) {
-                var_dump($e->getMessage());
-            } catch (ValidationException $e) {
-                var_dump($e->getMessage());
-            } catch (RequestException $e) {
-                var_dump(json_decode($e->getResponse()->getBody()));
-            }
-
-        } else {
-            echo 'ShopInShopPaymentRequest is not valid';
-        }
+        $transactionId = $response->getTransactionId();
 
         // Test payment status request with the transactionId we got from the PaymentRequest
         $psr = new PaymentStatusRequest();
         $psr->setTransactionId($transactionId);
 
         try {
-            $res = $client->getPaymentStatus($psr);
+            $res = $this->sisClient->getPaymentStatus($psr);
             $this->assertEquals('new', $res->getStatus());
-            $this->assertEquals($res->getTransactionId(), $transactionId);
-        } catch (HmacException $e) {
-            var_dump('hmac error');
-        } catch (ValidationException $e) {
-            var_dump('validation error');
+            $this->assertEquals($transactionId, $res->getTransactionId());
+        } catch (HmacException|ValidationException $e) {
+            $this->fail($e->getMessage());
         }
     }
 

--- a/tests/PaymentRequestTestCase.php
+++ b/tests/PaymentRequestTestCase.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests;
+
+use Paytrail\SDK\Client;
+use Paytrail\SDK\Exception\HmacException;
+use Paytrail\SDK\Exception\ValidationException;
+use Paytrail\SDK\Interfaces\PaymentRequestInterface;
+use Paytrail\SDK\Request\PaymentRequest;
+use Paytrail\SDK\Request\ShopInShopPaymentRequest;
+use Paytrail\SDK\Response\PaymentResponse;
+use PHPUnit\Framework\TestCase;
+
+abstract class PaymentRequestTestCase extends TestCase
+{
+    const SECRET = 'SAIPPUAKAUPPIAS';
+    const MERCHANT_ID = 375917;
+    const SHOP_IN_SHOP_SECRET = 'MONISAIPPUAKAUPPIAS';
+    const SHOP_IN_SHOP_AGGREGATE_MERCHANT_ID = 695861;
+    const SHOP_IN_SHOP_SUB_MERCHANT_ID = '695874';
+    const COF_PLUGIN_VERSION = 'phpunit-test';
+
+    /**
+     * Paytrail client instance.
+     *
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Paytrail client instance for shop-in-shop requests.
+     *
+     * @var Client
+     */
+    protected $sisClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client = new Client(self::MERCHANT_ID, self::SECRET, self::COF_PLUGIN_VERSION);
+        $this->sisClient = new Client(self::SHOP_IN_SHOP_AGGREGATE_MERCHANT_ID, self::SHOP_IN_SHOP_SECRET,
+            self::COF_PLUGIN_VERSION);
+    }
+
+    /**
+     * Create a payment request.
+     *
+     * @param PaymentRequest|PaymentRequestInterface $paymentRequest
+     * @return PaymentResponse
+     */
+    protected function createPayment(PaymentRequestInterface $paymentRequest): PaymentResponse
+    {
+        try {
+            $paymentRequest->validate();
+            return $this->client->createPayment($paymentRequest);
+        } catch (HmacException|ValidationException $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * Create a shop-in-shop payment request.
+     *
+     * @param ShopInShopPaymentRequest|PaymentRequestInterface $paymentRequest
+     * @return PaymentResponse
+     */
+    protected function createShopInShopPayment(PaymentRequestInterface $paymentRequest): PaymentResponse
+    {
+        try {
+            $paymentRequest->validate();
+            return $this->sisClient->createShopInShopPayment($paymentRequest);
+        } catch (HmacException|ValidationException $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * Asserts that a payment response is valid and has all the required fields.
+     *
+     * @param PaymentResponse $paymentResponse
+     * @return void
+     */
+    public static function assertPaymentResponseIsValid(PaymentResponse $paymentResponse): void
+    {
+        foreach (['transactionId', 'href', 'terms', 'groups', 'reference', 'providers'] as $field) {
+            static::assertObjectHasAttribute($field, $paymentResponse);
+        }
+
+        static::assertNotEmpty($paymentResponse->getTransactionId());
+        static::assertNotEmpty($paymentResponse->getHref());
+        static::assertNotEmpty($paymentResponse->getTerms());
+        static::assertNotEmpty($paymentResponse->getReference());
+        static::assertIsArray($paymentResponse->getGroups());
+        static::assertIsArray($paymentResponse->getProviders());
+    }
+}

--- a/tests/PaymentRequestTestCase.php
+++ b/tests/PaymentRequestTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests;
@@ -14,12 +15,12 @@ use PHPUnit\Framework\TestCase;
 
 abstract class PaymentRequestTestCase extends TestCase
 {
-    const SECRET = 'SAIPPUAKAUPPIAS';
-    const MERCHANT_ID = 375917;
-    const SHOP_IN_SHOP_SECRET = 'MONISAIPPUAKAUPPIAS';
-    const SHOP_IN_SHOP_AGGREGATE_MERCHANT_ID = 695861;
-    const SHOP_IN_SHOP_SUB_MERCHANT_ID = '695874';
-    const COF_PLUGIN_VERSION = 'phpunit-test';
+    protected const SECRET = 'SAIPPUAKAUPPIAS';
+    protected const MERCHANT_ID = 375917;
+    protected const SHOP_IN_SHOP_SECRET = 'MONISAIPPUAKAUPPIAS';
+    protected const SHOP_IN_SHOP_AGGREGATE_MERCHANT_ID = 695861;
+    protected const SHOP_IN_SHOP_SUB_MERCHANT_ID = '695874';
+    protected const COF_PLUGIN_VERSION = 'phpunit-test';
 
     /**
      * Paytrail client instance.
@@ -39,8 +40,11 @@ abstract class PaymentRequestTestCase extends TestCase
     {
         parent::setUp();
         $this->client = new Client(self::MERCHANT_ID, self::SECRET, self::COF_PLUGIN_VERSION);
-        $this->sisClient = new Client(self::SHOP_IN_SHOP_AGGREGATE_MERCHANT_ID, self::SHOP_IN_SHOP_SECRET,
-            self::COF_PLUGIN_VERSION);
+        $this->sisClient = new Client(
+            self::SHOP_IN_SHOP_AGGREGATE_MERCHANT_ID,
+            self::SHOP_IN_SHOP_SECRET,
+            self::COF_PLUGIN_VERSION
+        );
     }
 
     /**
@@ -53,8 +57,9 @@ abstract class PaymentRequestTestCase extends TestCase
     {
         try {
             $paymentRequest->validate();
+
             return $this->client->createPayment($paymentRequest);
-        } catch (HmacException|ValidationException $e) {
+        } catch (HmacException | ValidationException $e) {
             $this->fail($e->getMessage());
         }
     }
@@ -69,8 +74,9 @@ abstract class PaymentRequestTestCase extends TestCase
     {
         try {
             $paymentRequest->validate();
+
             return $this->sisClient->createShopInShopPayment($paymentRequest);
-        } catch (HmacException|ValidationException $e) {
+        } catch (HmacException | ValidationException $e) {
             $this->fail($e->getMessage());
         }
     }


### PR DESCRIPTION
## Related tickets & documents

- Includes #52 with no conflicts

## Description

- Fix PaymentResponse function and phpdoc types
- Add missing fields to PaymentResponse model
- Simplify PaymentReponse property binder setters
- Add base test case for payment request tests to avoid code duplication
- Add tests for new payment response fields
- Add some style fixes according to phpcs rules

Remember to add new classes to classmap before testing

```bash
composer dump-autoload
composer test
```

Lmk if you want any changes
