### PR TITLE
Add missing transaction-id to activateInvoice POST request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2022-12-19
+- Add missing transaction property to activateInvoice request
+
 ## [2.4.0] - 2022-11-15
 ### Added
 - Add missing properties to RefundRequest

--- a/src/Client.php
+++ b/src/Client.php
@@ -719,7 +719,8 @@ class Client extends PaytrailClient
             function ($decoded) {
                 return (new InvoiceActivationResponse())
                     ->setStatus($decoded->status);
-            }
+            },
+            $transactionId
         );
     }
 


### PR DESCRIPTION
Fixes the following error:

```
A problem occurred during Paytrail Api connection: Client error: `POST https://services.paytrail.com/payments/{transactionId}/activate-invoice` resulted in a `401 Unauthorized` response:
{"status":"error","message":"checkout-transaction-id header missing or value mismatch"}
``` 