### PR TITLE
Remove useless statement

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -167,10 +167,6 @@ class Client extends PaytrailClient
         // Instantiate providers.
         $decoded = json_decode($body);
 
-        array_map(function ($provider_data) {
-            return (new Provider())->bindProperties($provider_data);
-        }, $decoded->providers);
-
         $groups = array_map(function ($group_data) {
             return [
                 'id' => $group_data->id,


### PR DESCRIPTION
## Related tickets & documents

See 1bd773d849036e6285636215735e43b2958adc04

## Description

The result of `array_map` is not saved so the statement is probably useless.