### PR TITLE
Fail tests on E_DEPRECATED

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php" colors="true" stopOnFailure="false">
+<phpunit
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    convertDeprecationsToExceptions="true"
+    stopOnFailure="false"
+>
 <testsuites>
     <testsuite name="Paytrail PHP-SDK testsuite">
         <directory>tests</directory>


### PR DESCRIPTION
## Related tickets & documents

PHP 8.2 is stable and should be supported.

Some tests emitted `E_DEPRECATED` in PHP 8.2 due to use of dynamic properties, but it was fixed.

This PR makes phpunit to fail tests which emit `E_DEPRECATED` in order to be able to fix deprecated features before they are removed from a new version of PHP.

## Description

Deprecation notices (in phpunit) were fixed by https://github.com/paytrail/paytrail-php-sdk/pull/59