### PR TITLE
Fix requestSettlements url parameters

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -631,6 +631,12 @@ class Client extends PaytrailClient
 
         $uri = '/settlements';
 
+        $query = http_build_query($settlementRequest->jsonSerialize());
+
+        if (!empty($query)) {
+            $uri .= '?' . $query;
+        }
+
         return $this->get(
             $uri,
             function ($decoded) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -494,6 +494,12 @@ class ClientTest extends PaymentRequestTestCase
 
     public function testRequestSettlementsReturnsValidResponse()
     {
+        $settlementRequest = (new SettlementRequest());
+        $this->client->requestSettlements($settlementRequest);
+    }
+
+    public function testGetSettlementsReturnsValidResponse()
+    {
         $settlementRequest = new SettlementRequest();
         $settlementResponse = $this->client->requestSettlements($settlementRequest);
         $this->assertIsArray($settlementResponse->getSettlements());


### PR DESCRIPTION
## Description

Settlements endpoint expects parameters as url parameters, not in body. Pass them in request uri.

fix #73 
