### PR TITLE
Allow zero amount items

### DIFF
--- a/.github/workflows/run-workflow.yaml
+++ b/.github/workflows/run-workflow.yaml
@@ -31,7 +31,7 @@ jobs:
         run: composer lint
 
       - name: Run phpstan
-        uses: php-actions/phpstan@v3.0.1
+        uses: php-actions/phpstan@v3
         with:
           php_version: ${{ matrix.php-version }}
           version: 1.9.14
@@ -39,7 +39,7 @@ jobs:
           memory_limit: 256M
 
       - name: Run tests
-        uses: php-actions/phpunit@v3.0.0
+        uses: php-actions/phpunit@v3
         with:
           php_version: ${{ matrix.php-version }}
           version: 9

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -376,13 +376,16 @@ class Item implements \JsonSerializable, ItemInterface
     {
         $props = get_object_vars($this);
 
-        if (empty($props['unitPrice'])) {
+        if ($props['unitPrice'] === null) {
             throw new ValidationException('Item unitPrice is empty');
         }
         if ($props['unitPrice'] < 0) {
             throw new ValidationException('Items unitPrice can\'t be a negative number');
         }
-        if (empty($props['units'])) {
+        if ($props['unitPrice'] > 99999999) {
+            throw new ValidationException('Items unitPrice can\'t be over 99999999');
+        }
+        if ($props['units'] === null) {
             throw new ValidationException('Item units is empty');
         }
         if ($props['units'] < 0) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -495,7 +495,8 @@ class ClientTest extends PaymentRequestTestCase
     public function testRequestSettlementsReturnsValidResponse()
     {
         $settlementRequest = (new SettlementRequest());
-        $this->client->requestSettlements($settlementRequest);
+        $settlementResponse = $this->client->requestSettlements($settlementRequest);
+        $this->assertIsArray($settlementResponse->getSettlements());
     }
 
     public function testGetSettlementsReturnsValidResponse()

--- a/tests/Model/ItemTest.php
+++ b/tests/Model/ItemTest.php
@@ -20,25 +20,13 @@ class ItemTest extends TestCase
             ->setDeliveryDate('2023-01-01')
             ->setDescription('description');
 
-        $this->assertEquals(true, $item->validate());
+        $this->assertTrue($item->validate());
     }
 
     public function testItemWithoutUnitPriceThrowsError()
     {
         $this->expectException(ValidationException::class);
         (new Item())->setUnits(2)
-            ->setStamp('thisIsStamp')
-            ->setVatPercentage(0)
-            ->setProductCode('productCode123')
-            ->setDescription('description')
-            ->validate();
-    }
-
-    public function testItemWithNegativeUnitPriceThrowsError()
-    {
-        $this->expectException(ValidationException::class);
-        (new Item())->setUnitPrice(-1)
-            ->setUnits(2)
             ->setStamp('thisIsStamp')
             ->setVatPercentage(0)
             ->setProductCode('productCode123')
@@ -90,5 +78,37 @@ class ItemTest extends TestCase
             ->setVatPercentage(10)
             ->setDescription('description')
             ->validate();
+    }
+
+    public static function providerForUnitPriceLimitValues()
+    {
+        return [
+            'Negative amount' => [-1, false],
+            'Zero amount' => [0, true],
+            'Maximum amount' => [99999999, true],
+            'Over maximum amount' => [100000000, false]
+        ];
+    }
+
+    /**
+     * @dataProvider providerForUnitPriceLimitValues
+     */
+    public function testUnitPriceLimitValues($unitPrice, $expectedResult)
+    {
+        $item = (new Item())->setUnitPrice($unitPrice)
+            ->setUnits(2)
+            ->setStamp('thisIsStamp')
+            ->setVatPercentage(0)
+            ->setProductCode('productCode123')
+            ->setDeliveryDate('2023-01-01')
+            ->setDescription('description');
+
+        try {
+            $validationResult = $item->validate();
+        } catch (ValidationException $exception) {
+            $validationResult = false;
+        }
+
+        $this->assertEquals($expectedResult, $validationResult);
     }
 }


### PR DESCRIPTION
## Description

- Allow item with zero amount
- Change item price test to have data provider
- Add validation and test for minimum and maximum amount, as well as test for above maximum
- Remove useless sub versions from workflow actions
- Add datatype assertion to risky test without any assertion

fix #78 