### PR TITLE
Fix payment provider unit test

### DIFF
--- a/.github/workflows/run-workflow.yaml
+++ b/.github/workflows/run-workflow.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: php-actions/phpstan@v3
         with:
           php_version: ${{ matrix.php-version }}
-          version: 1.9.14
+          version: latest
           configuration: phpstan.neon
           memory_limit: 256M
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -23,6 +23,7 @@ use Paytrail\SDK\Request\ReportRequest;
 use Paytrail\SDK\Request\RevertPaymentAuthHoldRequest;
 use Paytrail\SDK\Request\SettlementRequest;
 use Paytrail\SDK\Request\ShopInShopPaymentRequest;
+use Paytrail\SDK\Model\Provider;
 
 class ClientTest extends PaymentRequestTestCase
 {
@@ -510,7 +511,8 @@ class ClientTest extends PaymentRequestTestCase
     {
         $providers = $this->client->getGroupedPaymentProviders(100, 'EN');
         $this->assertIsArray($providers);
-        $this->assertEquals('Mobile payment methods', $providers['groups'][0]['name']);
+        // Get first provider groups providers and select first provider from array.
+        $this->assertInstanceOf(Provider::class, $providers['groups'][0]['providers'][0]);
     }
 
     public function testRequestPaymentReportReturnsRequestId()


### PR DESCRIPTION
## Description

Test fails after reordering payment methods. Instead of expecting certain provider group, assert that provider inside group is Provider object.
