### PR TITLE
Fix access to possibly undefined property

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -220,7 +220,7 @@ class Client extends PaytrailClient
                     ->setGroups($decoded->groups ?? [])
                     ->setReference($decoded->reference ?? null)
                     ->setProviders($decoded->providers ?? [])
-                    ->setCustomProviders((array)$decoded->customProviders ?? []);
+                    ->setCustomProviders((array)($decoded->customProviders ?? []));
             }
         );
 


### PR DESCRIPTION
## Description

This fixes crash on version 2.7.0 caused by incorrect `null` coalesce:

```
Undefined property: stdClass::$customProviders

Error number: 2
.../vendor/paytrail/paytrail-php-sdk/src/Client.php: 223

.../vendor/paytrail/paytrail-php-sdk/src/PaytrailClient.php: 118: call_user_func(Closure,stdClass)
.../vendor/paytrail/paytrail-php-sdk/src/Client.php: 206: Paytrail\SDK\PaytrailClient->post('/payments',Paytrail\SDK\Request\PaymentRequest,Closure)
```

Current solution means "Read property `customProviders`, cast it to array and if the result is `null` then use `[]`".

Of course the result is never `null`, which should have been caught by PHPStan. Maybe the error level there is set too low.

```php
->setProviders($decoded->providers ?? [])
->setCustomProviders((array)$decoded->customProviders ?? []); // Undefined property
```

Need to use parentheses due to operator precedence:

```php
->setProviders($decoded->providers ?? [])
->setCustomProviders((array)($decoded->customProviders ?? []));
```