### PR TITLE
Run tests on PHP 8.3

### DIFF
--- a/.github/workflows/run-workflow.yaml
+++ b/.github/workflows/run-workflow.yaml
@@ -14,7 +14,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         experimental: [false]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

PHP 8.3 is stable and should be supported.
