### PR TITLE
remove negative rows validation

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -379,9 +379,6 @@ class Item implements \JsonSerializable, ItemInterface
         if ($props['unitPrice'] === null) {
             throw new ValidationException('Item unitPrice is empty');
         }
-        if ($props['unitPrice'] < 0) {
-            throw new ValidationException('Items unitPrice can\'t be a negative number');
-        }
         if ($props['unitPrice'] > 99999999) {
             throw new ValidationException('Items unitPrice can\'t be over 99999999');
         }

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -414,6 +414,10 @@ class Item implements \JsonSerializable, ItemInterface
             throw new ValidationException('merchant is empty');
         }
 
+        if ($props['unitPrice'] < 0) {
+            throw new ValidationException('Shop-in-shop item unitPrice can\'t be a negative number');
+        }
+
         return true;
     }
 }

--- a/tests/Model/ItemTest.php
+++ b/tests/Model/ItemTest.php
@@ -83,9 +83,19 @@ class ItemTest extends TestCase
     public static function providerForUnitPriceLimitValues()
     {
         return [
-            'Negative amount' => [-1, false],
-            'Zero amount' => [0, true],
-            'Maximum amount' => [99999999, true],
+            'Negative amount'     => [-1, true],
+            'Zero amount'         => [0, true],
+            'Maximum amount'      => [99999999, true],
+            'Over maximum amount' => [100000000, false]
+        ];
+    }
+
+    public static function providerForUnitPriceLimitValuesShopInShop()
+    {
+        return [
+            'Negative amount'     => [-1, false],
+            'Zero amount'         => [0, true],
+            'Maximum amount'      => [99999999, true],
             'Over maximum amount' => [100000000, false]
         ];
     }
@@ -110,5 +120,40 @@ class ItemTest extends TestCase
         }
 
         $this->assertEquals($expectedResult, $validationResult);
+    }
+
+    public function testValidateShopInShopThrowsExceptionWhenMerchantIsEmpty(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('merchant is empty');
+
+        $item = (new Item())
+            ->setUnitPrice(213)
+            ->setUnits(2)
+            ->setProductCode('pr1')
+            ->validateShopInShop();
+    }
+
+    /**
+     * @dataProvider providerForUnitPriceLimitValuesShopInShop
+     */
+    public function testValidateShopInShopThrowsExceptionWhenUnitPriceIsNegative($unitPrice, $expectedResult): void
+    {
+        $item = new Item();
+        $item->setUnitPrice($unitPrice);
+        $item->setUnits(2);
+        $item->setProductCode('pr1');
+        $item->setMerchant('merchant1');
+
+
+        try {
+            $item->validate();
+            $validationResult = $item->validateShopInShop();
+        } catch (ValidationException $exception) {
+            $validationResult = false;
+        }
+
+        $this->assertEquals($expectedResult, $validationResult);
+
     }
 }

--- a/tests/Model/ItemTest.php
+++ b/tests/Model/ItemTest.php
@@ -145,7 +145,6 @@ class ItemTest extends TestCase
         $item->setProductCode('pr1');
         $item->setMerchant('merchant1');
 
-
         try {
             $item->validate();
             $validationResult = $item->validateShopInShop();
@@ -154,6 +153,5 @@ class ItemTest extends TestCase
         }
 
         $this->assertEquals($expectedResult, $validationResult);
-
     }
 }

--- a/tests/Model/ItemTest.php
+++ b/tests/Model/ItemTest.php
@@ -121,37 +121,4 @@ class ItemTest extends TestCase
 
         $this->assertEquals($expectedResult, $validationResult);
     }
-
-    public function testValidateShopInShopThrowsExceptionWhenMerchantIsEmpty(): void
-    {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('merchant is empty');
-
-        $item = (new Item())
-            ->setUnitPrice(213)
-            ->setUnits(2)
-            ->setProductCode('pr1')
-            ->validateShopInShop();
-    }
-
-    /**
-     * @dataProvider providerForUnitPriceLimitValuesShopInShop
-     */
-    public function testValidateShopInShopThrowsExceptionWhenUnitPriceIsNegative($unitPrice, $expectedResult): void
-    {
-        $item = new Item();
-        $item->setUnitPrice($unitPrice);
-        $item->setUnits(2);
-        $item->setProductCode('pr1');
-        $item->setMerchant('merchant1');
-
-        try {
-            $item->validate();
-            $validationResult = $item->validateShopInShop();
-        } catch (ValidationException $exception) {
-            $validationResult = false;
-        }
-
-        $this->assertEquals($expectedResult, $validationResult);
-    }
 }

--- a/tests/Request/ShopInShopPaymentRequestTest.php
+++ b/tests/Request/ShopInShopPaymentRequestTest.php
@@ -14,8 +14,6 @@ use PHPUnit\Framework\TestCase;
 
 class ShopInShopPaymentRequestTest extends TestCase
 {
-
-
     public function testShopInShopPaymentRequest()
     {
         $r = new ShopInShopPaymentRequest();
@@ -140,7 +138,7 @@ class ShopInShopPaymentRequestTest extends TestCase
                 'amount'         => 10,
                 'expectedResult' => false
             ],
-            'positive validation'              =>  [
+            'positive validation'              => [
                 'itemsPrice'     => [20, 10],
                 'amount'         => 30,
                 'expectedResult' => true
@@ -160,7 +158,7 @@ class ShopInShopPaymentRequestTest extends TestCase
         $r->setCurrency('EUR');
         $r->setLanguage('EN');
 
-        $i = 0;
+        $i     = 0;
         $items = [];
         foreach ($itemsPrice as $price) {
             $com = new Commission();
@@ -202,10 +200,8 @@ class ShopInShopPaymentRequestTest extends TestCase
         $r->setRedirectUrls($redirect);
 
         try {
-
             $result = $r->validate();
         } catch (ValidationException $e) {
-            echo $e->getMessage();
             $result = false;
         }
 

--- a/tests/Request/ShopInShopPaymentRequestTest.php
+++ b/tests/Request/ShopInShopPaymentRequestTest.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\TestCase;
 
 class ShopInShopPaymentRequestTest extends TestCase
 {
+
+
     public function testShopInShopPaymentRequest()
     {
         $r = new ShopInShopPaymentRequest();
@@ -128,5 +130,85 @@ class ShopInShopPaymentRequestTest extends TestCase
         $r->setRedirectUrls($redirect);
 
         $r->validate();
+    }
+
+    public static function shopInShopPaymentRequestItems()
+    {
+        return [
+            'negative item failing validation' => [
+                'itemsPrice'     => [20, -10],
+                'amount'         => 10,
+                'expectedResult' => false
+            ],
+            'positive validation'              =>  [
+                'itemsPrice'     => [20, 10],
+                'amount'         => 30,
+                'expectedResult' => true
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider shopInShopPaymentRequestItems
+     */
+    public function testNegativeRowsValidation($itemsPrice, $amount, $expectedResult)
+    {
+        $r = new ShopInShopPaymentRequest();
+        $r->setAmount($amount);
+        $r->setStamp('RequestStamp');
+        $r->setReference('RequestReference123');
+        $r->setCurrency('EUR');
+        $r->setLanguage('EN');
+
+        $i = 0;
+        $items = [];
+        foreach ($itemsPrice as $price) {
+            $com = new Commission();
+            $com->setMerchant('123456');
+            $com->setAmount(2);
+
+            $item = new Item();
+            $item->setStamp('someStamp' . $i)
+                ->setDeliveryDate('12.12.2020')
+                ->setProductCode('pr1' . $i)
+                ->setVatPercentage(25)
+                ->setUnitPrice($price)
+                ->setUnits(1)
+                ->setMerchant('222222')
+                ->setReference('1-2')
+                ->setCommission($com);
+
+            $items[] = $item;
+            $i++;
+        }
+
+        $r->setItems($items);
+
+        $c = new Customer();
+        $c->setEmail('customer@email.com');
+
+        $r->setCustomer($c);
+
+        $cb = new CallbackUrl();
+        $cb->setCancel('https://somedomain.com/cancel')
+            ->setSuccess('https://somedomain.com/success');
+
+        $r->setCallbackUrls($cb);
+
+        $redirect = new CallbackUrl();
+        $redirect->setSuccess('https://someother.com/success')
+            ->setCancel('https://someother.com/cancel');
+
+        $r->setRedirectUrls($redirect);
+
+        try {
+
+            $result = $r->validate();
+        } catch (ValidationException $e) {
+            echo $e->getMessage();
+            $result = false;
+        }
+
+        $this->assertEquals($expectedResult, $result);
     }
 }


### PR DESCRIPTION
This pull request primarily focuses on adjusting the validation logic for item prices in the `src/Model/Item.php` file and updating the corresponding tests. The changes ensure that negative prices are not allowed for items in general, but specifically for shop-in-shop items. The tests have been updated to reflect this change.

Main changes include:

Changes in `src/Model/Item.php`:

* [`public function validate()`](diffhunk://#diff-785d24b46fdf749363656f33208f941ea0eca809c7c76452180a0bfc16df68a3L382-L384): Removed the check for negative prices. This allows items to have negative prices.
* [`public function validateShopInShop()`](diffhunk://#diff-785d24b46fdf749363656f33208f941ea0eca809c7c76452180a0bfc16df68a3R417-R420): Added a validation rule that prevents shop-in-shop items from having negative prices.

Changes in test files:

* [`tests/Model/ItemTest.php`](diffhunk://#diff-b282226e6021b74e513873a36743327314d14100f0df23e149d0d1aa616caba9R84-R93): Added a new data provider `providerForUnitPriceLimitValuesShopInShop` for testing different price scenarios for shop-in-shop items.
* [`tests/Request/ShopInShopPaymentRequestTest.php`](diffhunk://#diff-0d2ab0f3d8d01fddbd46c4d3117662f0a214f71e2dcd266eb9081666659e22caR132-R209): Added a new test `testNegativeRowsValidation` to verify the validation of negative prices for shop-in-shop items. This test uses the new data provider `shopInShopPaymentRequestItems`.