### PR TITLE
Fix submerchant parameter for SettlementRequest, ReportBySettlementRequest and ReportRequest

### DIFF
--- a/src/Request/ReportBySettlementRequest.php
+++ b/src/Request/ReportBySettlementRequest.php
@@ -11,7 +11,7 @@ class ReportBySettlementRequest implements \JsonSerializable
     protected $requestType;
     protected $callbackUrl;
     protected $reportFields;
-    protected $subMerchant;
+    protected $submerchant;
 
     public function validate()
     {
@@ -74,12 +74,12 @@ class ReportBySettlementRequest implements \JsonSerializable
     /**
      * Set submerchant.
      *
-     * @param int $subMerchant
+     * @param int $submerchant
      * @return $this
      */
-    public function setSubMerchant(int $subMerchant): self
+    public function setSubMerchant(int $submerchant): self
     {
-        $this->subMerchant = $subMerchant;
+        $this->submerchant = $submerchant;
         return $this;
     }
 

--- a/src/Request/ReportRequest.php
+++ b/src/Request/ReportRequest.php
@@ -22,7 +22,7 @@ class ReportRequest implements \JsonSerializable
     private $endDate;
     private $limit;
     private $reportFields;
-    private $subMerchant;
+    private $submerchant;
 
     public function validate()
     {
@@ -164,12 +164,12 @@ class ReportRequest implements \JsonSerializable
     /**
      * Set submerchant.
      *
-     * @param int $subMerchant
+     * @param int $submerchant
      * @return $this
      */
-    public function setSubMerchant(int $subMerchant): self
+    public function setSubMerchant(int $submerchant): self
     {
-        $this->subMerchant = $subMerchant;
+        $this->submerchant = $submerchant;
         return $this;
     }
 

--- a/src/Request/SettlementRequest.php
+++ b/src/Request/SettlementRequest.php
@@ -15,7 +15,7 @@ class SettlementRequest implements \JsonSerializable
     protected $endDate;
     protected $reference;
     protected $limit;
-    protected $subMerchant;
+    protected $submerchant;
 
     public function validate()
     {
@@ -102,12 +102,12 @@ class SettlementRequest implements \JsonSerializable
     /**
      * Set submerchant.
      *
-     * @param int $subMerchant
+     * @param int $submerchant
      * @return $this
      */
-    public function setSubMerchant(int $subMerchant): self
+    public function setSubMerchant(int $submerchant): self
     {
-        $this->subMerchant = $subMerchant;
+        $this->submerchant = $submerchant;
         return $this;
     }
 


### PR DESCRIPTION
This will fix error where settlement and report requests received "Request payload schema validation failed. Validate request against the provided schema.","meta":["instance is not allowed to have the additional property \"subMerchant\"
