### PR TITLE
Add support for PHP 8.4

### DIFF
--- a/.github/workflows/run-workflow.yaml
+++ b/.github/workflows/run-workflow.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: php-actions/phpstan@v3
         with:
           php_version: ${{ matrix.php-version }}
-          version: latest
+          version: composer
           configuration: phpstan.neon
           memory_limit: 256M
 

--- a/.github/workflows/run-workflow.yaml
+++ b/.github/workflows/run-workflow.yaml
@@ -14,7 +14,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         experimental: [false]
     steps:
       - uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "squizlabs/php_codesniffer": "^3.6",
         "phpcompatibility/php-compatibility": "^9.3",
         "phpmd/phpmd": "^2.10",
-        "phpstan/phpstan": "1.9.14",
+        "phpstan/phpstan": "1.12.16",
         "mockery/mockery": "^1.5",
         "guzzlehttp/guzzle": "^7.0|^6.0"
     },

--- a/src/Client.php
+++ b/src/Client.php
@@ -85,7 +85,7 @@ class Client extends PaytrailClient
      * @throws ClientException
      * @throws RequestException    A Guzzle HTTP request exception is thrown for erroneous requests.
      */
-    public function getPaymentProviders(int $amount = null): array
+    public function getPaymentProviders(?int $amount = null): array
     {
         $uri = '/merchants/payment-providers';
 
@@ -134,7 +134,7 @@ class Client extends PaytrailClient
      * @throws ClientException
      * @throws RequestException A Guzzle HTTP request exception is thrown for erroneous requests.
      */
-    public function getGroupedPaymentProviders(int $amount = null, string $locale = 'FI', array $groups = []): array
+    public function getGroupedPaymentProviders(?int $amount = null, string $locale = 'FI', array $groups = []): array
     {
         $uri = '/merchants/grouped-payment-providers';
 

--- a/src/PaytrailClient.php
+++ b/src/PaytrailClient.php
@@ -73,11 +73,11 @@ abstract class PaytrailClient
      */
     protected function post(
         string $uri,
-        \JsonSerializable $data = null,
-        callable $callback = null,
-        string $transactionId = null,
+        ?\JsonSerializable $data = null,
+        ?callable $callback = null,
+        ?string $transactionId = null,
         bool $signatureInHeader = true,
-        string $paytrailTokenizationId = null
+        ?string $paytrailTokenizationId = null
     ) {
         $body = json_encode($data, JSON_UNESCAPED_SLASHES);
 
@@ -133,7 +133,7 @@ abstract class PaytrailClient
      * @return mixed
      * @throws HmacException
      */
-    protected function get(string $uri, callable $callback = null, string $transactionId = null)
+    protected function get(string $uri, ?callable $callback = null, ?string $transactionId = null)
     {
         $headers = $this->getHeaders('GET', $transactionId);
         $mac = $this->calculateHmac($headers);
@@ -170,8 +170,8 @@ abstract class PaytrailClient
      */
     protected function getHeaders(
         string $method,
-        string $transactionId = null,
-        string $checkoutTokenizationId = null
+        ?string $transactionId = null,
+        ?string $checkoutTokenizationId = null
     ): array {
         $datetime = new \DateTime();
 


### PR DESCRIPTION
## Description

PHP 8.4 is stable and should be supported.

* Update phpstan
  * Latest version to support both PHP 7.3 and 8.4
* Run tests on PHP 8.4
* Fix PHP 8.4 deprecations
  * https://wiki.php.net/rfc/deprecate-implicitly-nullable-types