### PR TITLE
Item: Add validation for empty vatPercentage

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -388,6 +388,9 @@ class Item implements \JsonSerializable, ItemInterface
         if ($props['units'] < 0) {
             throw new ValidationException('Items units can\'t be a negative number');
         }
+        if ($props['vatPercentage'] === null) {
+            throw new ValidationException('Item vatPercentage is empty');
+        }
         if ($props['vatPercentage'] < 0) {
             throw new ValidationException('Items vatPercentage can\'t be a negative number');
         }

--- a/tests/Model/ItemTest.php
+++ b/tests/Model/ItemTest.php
@@ -57,6 +57,17 @@ class ItemTest extends TestCase
             ->validate();
     }
 
+    public function testItemWithoutVatThrowsError()
+    {
+        $this->expectException(ValidationException::class);
+        (new Item())->setUnitPrice(1)
+            ->setUnits(2)
+            ->setStamp('thisIsStamp')
+            ->setProductCode('productCode123')
+            ->setDescription('description')
+            ->validate();
+    }
+
     public function testItemWIthNegativeVatThrowsError()
     {
         $this->expectException(ValidationException::class);


### PR DESCRIPTION
## Description

Since `vatPercentage` is [required](https://docs.paytrail.com/#/?id=item) we should validate that Item has non-null `vatPercentage`.
Currently in master Item validation passes, but Paytrail API responds with 400 schema error.