### PR TITLE
Fix guzzle 7.11 deprecation: Don't pass int as header

### DIFF
--- a/src/PaytrailClient.php
+++ b/src/PaytrailClient.php
@@ -176,7 +176,7 @@ abstract class PaytrailClient
         $datetime = new \DateTime();
 
         $headers = [
-            'checkout-account' => $this->merchantId,
+            'checkout-account' => (string)$this->merchantId,
             'checkout-algorithm' => 'sha256',
             'checkout-method' => strtoupper($method),
             'checkout-nonce' => uniqid('', true),


### PR DESCRIPTION
[Guzzle 7.11.0](https://github.com/guzzle/guzzle/releases/tag/7.11.0) deprecated passing non-string HTTP headers:

* Deprecated non-string `headers` request option values, which will be rejected in 8.0

Current SDK sends `checkout-account` as `int`, which triggers `E_USER_DEPRECATED`:

```
Since guzzlehttp/guzzle 7.11: Passing int to request option "headers.checkout-account" is deprecated; guzzlehttp/guzzle 8.0 requires string|non-empty-array<array-key, string>.

.../vendor/symfony/deprecation-contracts/function.php: 25: trigger_error()
.../vendor/guzzlehttp/guzzle/src/Client.php: 772: trigger_deprecation()
.../vendor/guzzlehttp/guzzle/src/Client.php: 544: GuzzleHttp\Client::warnInvalidRequestOptionType()
.../vendor/guzzlehttp/guzzle/src/Client.php: 405: GuzzleHttp\Client::warnAboutInvalidHeaderOptionTypes()
.../vendor/guzzlehttp/guzzle/src/Client.php: 364: GuzzleHttp\Client::warnAboutInvalidRequestOptionTypes()
.../vendor/guzzlehttp/guzzle/src/Client.php: 181: GuzzleHttp\Client->prepareDefaults()
.../vendor/guzzlehttp/guzzle/src/Client.php: 229: GuzzleHttp\Client->requestAsync()
.../vendor/paytrail/paytrail-php-sdk/src/Util/RequestClient.php: 42: GuzzleHttp\Client->request()
.../vendor/paytrail/paytrail-php-sdk/src/Client.php: 109: Paytrail\SDK\Util\RequestClient->request()
```

This is fixed by casting  the `checkout-account` header value to `string`.