### PR TITLE
NetworkToken: image_url no longer mandatory

### DIFF
--- a/src/Model/Token/NetworkToken.php
+++ b/src/Model/Token/NetworkToken.php
@@ -202,7 +202,7 @@ class NetworkToken implements \JsonSerializable
         $this->setPartialPan($networkToken->partial_pan);
         $this->setExpireYear($networkToken->expire_year);
         $this->setExpireMonth($networkToken->expire_month);
-        $this->setImageUrl($networkToken->image_url);
+        $this->setImageUrl($networkToken->image_url ?? null);
         $this->setPaymentAccountReference($networkToken->payment_account_reference ?? null);
 
 


### PR DESCRIPTION
## Related tickets & documents



## Description

Seems some provider leave out image_url, it being null and causing paytrail php sdk to crash. Adding ?? null here. Seems to work.
